### PR TITLE
Create Project File and Source Init File

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -1,0 +1,6 @@
+{
+	"name": "FormatNumber",
+	"tree": {
+		"$path": "src"
+	}
+}

--- a/src/init.lua
+++ b/src/init.lua
@@ -1,0 +1,10 @@
+local FormatNumber = {}
+
+FormatNumber.Version = require(script.Version)
+
+FormatNumber.Main = require(script.Main)
+FormatNumber.Simple = require(script.Simple)
+
+FormatNumber.Test = require(script.Test)
+
+return FormatNumber


### PR DESCRIPTION
- The project file allows for the hierarchy to be automatically organized out when syncing with Rojo.
- The `src/init.lua` file is just so the hierarchy is completely modules instead of Folder>Module.
  - There could be improvements, such as using `table.freeze`, since I only put the code for it to be laid out.